### PR TITLE
Changes to the gulp build flow

### DIFF
--- a/content/homepage/homepage.md
+++ b/content/homepage/homepage.md
@@ -9,5 +9,5 @@ redirect_from:
 
 ---
 
-This is the homepage.
+This is the homepage. Foo! Bar!
 {% include site-tree.html context="/" %}

--- a/content/homepage/homepage.md
+++ b/content/homepage/homepage.md
@@ -9,5 +9,5 @@ redirect_from:
 
 ---
 
-This is the homepage. Foo! Bar!
+This is the homepage.
 {% include site-tree.html context="/" %}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,37 +8,38 @@ var paths = {
  js: ['assets/js/main.js'],
 };
 
+var jekyll   = process.platform === 'win32' ? 'jekyll.bat' : 'jekyll';
+var messages = {
+    jekyllBuild: 'Rebuilding incrementally...',
+    jekyllBuildComplete: 'Rebuilding complete site...'
+};
+
 const browserSync = require('browser-sync').create();
 const siteRoot = '_site';
 
 
-// Running Jekyll via Gulp
-// via https://aaronlasseigne.com/2016/02/03/using-gulp-with-jekyll/
-gulp.task('jekyll', () => {
-  const jekyll = child.spawn('jekyll', ['build',
-    '--watch',
-    '--incremental',
-    '--drafts'
-  ]);
-
-  const jekyllLogger = (buffer) => {
-    buffer.toString()
-      .split(/\n/)
-      .forEach((message) => gutil.log('Jekyll: ' + message));
-  };
-  notify({
-    title: 'Done!',
-    message: "<%= file.relative %>",
-    // 'sound': 'Hero' //Look in /System/Library/Sounds for other sounds
-    'sound': 'Pop'
-  });
-  jekyll.stdout.on('data', jekyllLogger);
-  jekyll.stderr.on('data', jekyllLogger);
+gulp.task('jekyll-build', function (done) {
+    browserSync.notify(messages.jekyllBuild);
+    return child.spawn( jekyll , ['build', '--incremental', '--drafts'], {stdio: 'inherit'})
+        .on('close', done);
 });
 
-gulp.task('serve', () => {
+gulp.task('jekyll-build-complete', function (done) {
+    browserSync.notify(messages.jekyllBuildComplete);
+    return child.spawn( jekyll , ['build', '--drafts'], {stdio: 'inherit'})
+        .on('close', done);
+});
+
+gulp.task('jekyll-rebuild', ['jekyll-build'], function () {
+    browserSync.reload();
+});
+
+gulp.task('jekyll-rebuild-complete', ['jekyll-build-complete'], function () {
+    browserSync.reload();
+});
+
+gulp.task('serve', ['jekyll-build'], function() {
   browserSync.init({
-    files: [siteRoot + '/**'],
     port: 4000,
     server: {
       baseDir: siteRoot
@@ -46,11 +47,24 @@ gulp.task('serve', () => {
   });
 });
 
+
 // // Gulp watch
 // gulp.task('watch', function(){
-//   gulp.watch('assets/scss/*.scss', ['sass']); 
+//   gulp.watch('assets/scss/*.scss', ['sass']);
 //   gulp.watch('assets/scss/*/*.scss', ['sass']);
 //   gulp.watch('assets/js/*.js', ['jshint']);
 // })
 
-gulp.task('default', ['jekyll', 'serve']);
+gulp.task('watch', function () {
+    gulp.watch([
+      '_includes/**/*',
+      '_layouts/**/*',
+      '_posts/**/*',
+      'content/**/*'
+    ], ['jekyll-rebuild']);
+    gulp.watch([
+      '_data/**/*'
+    ], ['jekyll-rebuild-complete']);
+});
+
+gulp.task('default', ['serve', 'watch']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -31,20 +31,45 @@ gulp.task('jekyll-build-complete', function (done) {
 });
 
 gulp.task('jekyll-rebuild', ['jekyll-build'], function () {
-    browserSync.reload();
+  return gulp.src("/")
+    .pipe(notify({
+      "title": "digital.gov",
+      "subtitle": "Incremental build finished.",
+      "message": "Project reloaded.",
+      "sound": "Pop" // case sensitive
+    }))
+    .pipe(browserSync.stream());
 });
 
 gulp.task('jekyll-rebuild-complete', ['jekyll-build-complete'], function () {
-    browserSync.reload();
+  return gulp.src("/")
+    .pipe(notify({
+      "title": "digital.gov",
+      "subtitle": "Complete build finished.",
+      "message": "Project reloaded.",
+      "sound": "Pop" // case sensitive
+    }))
+    .pipe(browserSync.stream());
 });
 
-gulp.task('serve', ['jekyll-build'], function() {
+gulp.task('serve', ['jekyll-build-complete'], function() {
   browserSync.init({
     port: 4000,
     server: {
       baseDir: siteRoot
     }
   });
+});
+
+gulp.task('jekyll-first-build', ['serve'], function () {
+  return gulp.src("/")
+    .pipe(notify({
+      "title": "digital.gov",
+      "subtitle": "Initial build finished.",
+      "message": "Project loaded at localhost:4000.",
+      "sound": "Pop" // case sensitive
+    }))
+    .pipe(browserSync.stream());
 });
 
 
@@ -67,4 +92,4 @@ gulp.task('watch', function () {
     ], ['jekyll-rebuild-complete']);
 });
 
-gulp.task('default', ['serve', 'watch']);
+gulp.task('default', ['jekyll-first-build', 'watch']);


### PR DESCRIPTION
Not the most elegant solution, but works. 

Fixed the gulp flow to do a complete rebuild when data files change, instead of incremental, which wasn't working. Added some new pipes to make the `gulp-notify` notifications work. 

Now each change/build will trigger a notification and a browsersync reload. Is this overkill? We'll see!