### PR TITLE
Fixed path for header img

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,5 @@
 title: digital.gov
 email: DigitalGov@gsa.gov
-url: /
 
 twitter_username: digitalgov
 # github_username:  18F

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,7 +6,7 @@
         <div class="box">
 
           <h1>
-            <a href="{{ site.url }}" title="DigitalGov" rel="home"><img class="logo" src="{{ root_url }}/assets/img/DigitalGov_Horizontal.png" alt="{{ header.title | default: site.title }}"></a>
+            <a href="{{ site.url }}" title="DigitalGov" rel="home"><img class="logo" src="{{ site.url }}/assets/img/DigitalGov_Horizontal.png" alt="{{ header.title | default: site.title }}"></a>
             </a>
           </h1>
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,7 +6,7 @@
         <div class="box">
 
           <h1>
-            <a href="{{ site.url }}" title="DigitalGov" rel="home"><img class="logo" src="{{ site.url }}/assets/img/DigitalGov_Horizontal.png" alt="{{ header.title | default: site.title }}"></a>
+            <a href="{{ site.url }}" title="DigitalGov" rel="home"><img class="logo" src="{{ site.baseurl }}/assets/img/DigitalGov_Horizontal.png" alt="{{ header.title | default: site.title }}"></a>
             </a>
           </h1>
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,7 +6,7 @@
         <div class="box">
 
           <h1>
-            <a href="{{ site.url }}" title="DigitalGov" rel="home"><img class="logo" src="assets/img/DigitalGov_Horizontal.png" alt="{{ header.title | default: site.title }}"></a>
+            <a href="{{ site.url }}" title="DigitalGov" rel="home"><img class="logo" src="/assets/img/DigitalGov_Horizontal.png" alt="{{ header.title | default: site.title }}"></a>
             </a>
           </h1>
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,7 +6,7 @@
         <div class="box">
 
           <h1>
-            <a href="{{ site.url }}" title="DigitalGov" rel="home"><img class="logo" src="{{ root_url }}/assets/img/DigitalGov_Horizontal.png" alt="{{ header.title | default: site.title }}"></a>
+            <a href="{{ site.url }}" title="DigitalGov" rel="home"><img class="logo" src="/assets/img/DigitalGov_Horizontal.png" alt="{{ header.title | default: site.title }}"></a>
             </a>
           </h1>
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,7 +6,7 @@
         <div class="box">
 
           <h1>
-            <a href="{{ site.url }}" title="DigitalGov" rel="home"><img class="logo" src="{{ site.baseurl }}/assets/img/DigitalGov_Horizontal.png" alt="{{ header.title | default: site.title }}"></a>
+            <a href="{{ site.url }}{{ site.baseurl }}/index.html" title="DigitalGov" rel="home"><img class="logo" src="{{ site.baseurl }}/assets/img/DigitalGov_Horizontal.png" alt="{{ header.title | default: site.title }}"></a>
             </a>
           </h1>
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,7 +6,7 @@
         <div class="box">
 
           <h1>
-            <a href="{{ site.url }}" title="DigitalGov" rel="home"><img class="logo" src="/assets/img/DigitalGov_Horizontal.png" alt="{{ header.title | default: site.title }}"></a>
+            <a href="{{ site.url }}" title="DigitalGov" rel="home"><img class="logo" src="{{ root_url }}/assets/img/DigitalGov_Horizontal.png" alt="{{ header.title | default: site.title }}"></a>
             </a>
           </h1>
 


### PR DESCRIPTION
Adds more global path to the header image. `/assets/*` vs `assets/*`
This could/should probably change to a variable in the future.
Works now, though!

<img width="988" alt="screen shot 2017-05-18 at 10 29 45 am" src="https://cloud.githubusercontent.com/assets/11464021/26207215/ea685574-3bb4-11e7-9540-8cd7428d9071.png">
