### PR TITLE
Add default image include for legacy archive images

### DIFF
--- a/_includes/image.html
+++ b/_includes/image.html
@@ -17,4 +17,4 @@
 
 {% assign img-base-url = img-base-url | strip %}
 
-<img src="{{ img-base-url }}" alt="{{ include.alt}}"{% if include.width %}  width="{{ include.width}}"{% endif %}{% if include.height %}  height="{{ include.width}}"{% endif %}/>
+<img src="{{ img-base-url }}" alt="{{ include.alt | default: 'image' }}"{% if include.width %} width="{{ include.width }}"{% endif %}{% if include.height %} height="{{ include.height }}"{% endif %}/>

--- a/_includes/image.html
+++ b/_includes/image.html
@@ -3,18 +3,31 @@
 {% assign thisImage = include.img %}
 
 {% if include.img contains 'http' %}
-{% elsif include.img contains 'assets/img' %}
+  {% assign img-url = thisImage %}
+{% elsif include.img contains 'assets/img/' %}
   {% assign thisImage = include.img | prepend: '/' | replace: '//', '/' %}
-  {% capture img-base-url %}
+  {% capture img-url %}
   {{ site.baseurl }}{{ thisImage }}
   {% endcapture %}
+{% elsif include.img contains 'img/' %}
+  {% if include.img contains 'assets/' %}
+    {% assign thisImage = include.img | prepend: '/' | replace: '//', '/' %}
+    {% capture img-url %}
+    {{ site.baseurl }}{{ thisImage }}
+    {% endcapture %}
+  {% else %}
+    {% assign thisImage = include.img | prepend: '/assets/' | replace: '//', '/' %}
+    {% capture img-url %}
+    {{ site.baseurl }}{{ thisImage }}
+    {% endcapture %}
+  {% endif %}
 {% else %}
   {% assign thisImage = include.img | prepend: '/' | replace: '//', '/' %}
-  {% capture img-base-url %}
+  {% capture img-url %}
   {{ site.baseurl }}/assets/img{{ thisImage }}
   {% endcapture %}
 {% endif %}
 
-{% assign img-base-url = img-base-url | strip %}
+{% assign img-url = img-url | strip %}
 
-<img src="{{ img-base-url }}" alt="{{ include.alt | default: 'image' }}"{% if include.width %} width="{{ include.width }}"{% endif %}{% if include.height %} height="{{ include.height }}"{% endif %}/>
+<img src="{{ img-url }}" alt="{{ include.alt | default: 'image' }}"{% if include.width %} width="{{ include.width }}"{% endif %}{% if include.height %} height="{{ include.height }}"{% endif %}/>

--- a/_includes/image.html
+++ b/_includes/image.html
@@ -1,11 +1,20 @@
 
 {% assign thisStyle = "manual" %}
+{% assign thisImage = include.img %}
 
 {% if include.img contains 'http' %}
+{% elsif include.img contains 'assets/img' %}
+  {% assign thisImage = include.img | prepend: '/' | replace: '//', '/' %}
+  {% capture img-base-url %}
+  {{ site.baseurl }}{{ thisImage }}
+  {% endcapture %}
 {% else %}
-{{ thisImage = include.img | prepend: '/' | replace: '//', '/' }}
-{% capture img-base-url %}{{ site.baseurl }}{{ thisImage }}{% endcapture %}
+  {% assign thisImage = include.img | prepend: '/' | replace: '//', '/' %}
+  {% capture img-base-url %}
+  {{ site.baseurl }}/assets/img{{ thisImage }}
+  {% endcapture %}
 {% endif %}
 
+{% assign img-base-url = img-base-url | strip %}
 
 <img src="{{ img-base-url }}" alt="{{ include.alt}}"{% if include.width %}  width="{{ include.width}}"{% endif %}{% if include.height %}  height="{{ include.width}}"{% endif %}/>

--- a/_includes/image.html
+++ b/_includes/image.html
@@ -1,0 +1,11 @@
+
+{% assign thisStyle = "manual" %}
+
+{% if include.img contains 'http' %}
+{% else %}
+{{ thisImage = include.img | prepend: '/' | replace: '//', '/' }}
+{% capture img-base-url %}{{ site.baseurl }}{{ thisImage }}{% endcapture %}
+{% endif %}
+
+
+<img src="{{ img-base-url }}" alt="{{ include.alt}}"{% if include.width %}  width="{{ include.width}}"{% endif %}{% if include.height %}  height="{{ include.width}}"{% endif %}/>

--- a/_posts/2017-05-10-the-data-briefing-how-to-best-prepare-federal-government-datasets-for-chatbots.md
+++ b/_posts/2017-05-10-the-data-briefing-how-to-best-prepare-federal-government-datasets-for-chatbots.md
@@ -30,7 +30,7 @@ Along with [mobile apps](https://www.WHATEVER/2016/01/27/the-data-briefing-impro
 
 Enter the chatbot. [Chatbots](https://www.WHATEVER/2016/04/20/the-data-briefing-chatbots-and-the-rise-of-conversational-commerce-and-citizen-experience/) put a friendly face on the data sets and informational content of a website. The number of chatbots has exploded in recent years as users prefer to interact conversationally rather than using an online search. [Chatbots have personalities](https://chatbotsmagazine.com/how-to-write-for-a-bot-ce8afc25e54b?source=email-92b5c875be4d-1493983821063-digest.reader------0-6&sectionName=top) and can often sound like you are talking to a friend rather than a bunch of “if this, then” algorithms. [The U.S. federal government is in the process of building chatbots](http://www.fedtechmagazine.com/article/2017/02/chatbot-here-help), so expect to see more federal government chatbots being released in 2017 and 2018.
 
-{% include image/full-width.html img="https://www.WHATEVER/files/2017/05/600-x-400-low-res-Chatbot-concept-with-instant-messenger-displayed-on-smart-phone-a-image-iStock-Thinkstock-588366818.jpg" alt="Chatbot concept with instant messenger displayed on smart phone" %}
+{% include image.html img="/raw/lunch-team.png" alt="Chatbot concept with instant messenger displayed on smart phone" %}
 
 So, how do agencies prepare their government datasets for chatbots? The key is to think conversationally. How will users ask about the data and what should the responses be? Follow the steps below to map how your agency’s datasets will be transformed into a conversation.
 

--- a/_posts/2017-05-10-the-data-briefing-how-to-best-prepare-federal-government-datasets-for-chatbots.md
+++ b/_posts/2017-05-10-the-data-briefing-how-to-best-prepare-federal-government-datasets-for-chatbots.md
@@ -30,7 +30,7 @@ Along with [mobile apps](https://www.WHATEVER/2016/01/27/the-data-briefing-impro
 
 Enter the chatbot. [Chatbots](https://www.WHATEVER/2016/04/20/the-data-briefing-chatbots-and-the-rise-of-conversational-commerce-and-citizen-experience/) put a friendly face on the data sets and informational content of a website. The number of chatbots has exploded in recent years as users prefer to interact conversationally rather than using an online search. [Chatbots have personalities](https://chatbotsmagazine.com/how-to-write-for-a-bot-ce8afc25e54b?source=email-92b5c875be4d-1493983821063-digest.reader------0-6&sectionName=top) and can often sound like you are talking to a friend rather than a bunch of “if this, then” algorithms. [The U.S. federal government is in the process of building chatbots](http://www.fedtechmagazine.com/article/2017/02/chatbot-here-help), so expect to see more federal government chatbots being released in 2017 and 2018.
 
-{% include image.html img="/raw/lunch-team.png" alt="Chatbot concept with instant messenger displayed on smart phone" %}
+{% include image.html img="/raw/lunch-team.png" alt="Chatbot concept with instant messenger displayed on smart phone" width="200" %}
 
 So, how do agencies prepare their government datasets for chatbots? The key is to think conversationally. How will users ask about the data and what should the responses be? Follow the steps below to map how your agency’s datasets will be transformed into a conversation.
 

--- a/_posts/2017-05-10-the-data-briefing-how-to-best-prepare-federal-government-datasets-for-chatbots.md
+++ b/_posts/2017-05-10-the-data-briefing-how-to-best-prepare-federal-government-datasets-for-chatbots.md
@@ -30,7 +30,7 @@ Along with [mobile apps](https://www.WHATEVER/2016/01/27/the-data-briefing-impro
 
 Enter the chatbot. [Chatbots](https://www.WHATEVER/2016/04/20/the-data-briefing-chatbots-and-the-rise-of-conversational-commerce-and-citizen-experience/) put a friendly face on the data sets and informational content of a website. The number of chatbots has exploded in recent years as users prefer to interact conversationally rather than using an online search. [Chatbots have personalities](https://chatbotsmagazine.com/how-to-write-for-a-bot-ce8afc25e54b?source=email-92b5c875be4d-1493983821063-digest.reader------0-6&sectionName=top) and can often sound like you are talking to a friend rather than a bunch of “if this, then” algorithms. [The U.S. federal government is in the process of building chatbots](http://www.fedtechmagazine.com/article/2017/02/chatbot-here-help), so expect to see more federal government chatbots being released in 2017 and 2018.
 
-{% include image.html img="https://www.example.org/img/raw/lunch-team.png" alt="Chatbot concept with instant messenger displayed on smart phone" width="200" %}
+{% include image/full-width.html img="https://www.WHATEVER/files/2017/05/600-x-400-low-res-Chatbot-concept-with-instant-messenger-displayed-on-smart-phone-a-image-iStock-Thinkstock-588366818.jpg" alt="Chatbot concept with instant messenger displayed on smart phone" %}
 
 So, how do agencies prepare their government datasets for chatbots? The key is to think conversationally. How will users ask about the data and what should the responses be? Follow the steps below to map how your agency’s datasets will be transformed into a conversation.
 

--- a/_posts/2017-05-10-the-data-briefing-how-to-best-prepare-federal-government-datasets-for-chatbots.md
+++ b/_posts/2017-05-10-the-data-briefing-how-to-best-prepare-federal-government-datasets-for-chatbots.md
@@ -30,7 +30,7 @@ Along with [mobile apps](https://www.WHATEVER/2016/01/27/the-data-briefing-impro
 
 Enter the chatbot. [Chatbots](https://www.WHATEVER/2016/04/20/the-data-briefing-chatbots-and-the-rise-of-conversational-commerce-and-citizen-experience/) put a friendly face on the data sets and informational content of a website. The number of chatbots has exploded in recent years as users prefer to interact conversationally rather than using an online search. [Chatbots have personalities](https://chatbotsmagazine.com/how-to-write-for-a-bot-ce8afc25e54b?source=email-92b5c875be4d-1493983821063-digest.reader------0-6&sectionName=top) and can often sound like you are talking to a friend rather than a bunch of “if this, then” algorithms. [The U.S. federal government is in the process of building chatbots](http://www.fedtechmagazine.com/article/2017/02/chatbot-here-help), so expect to see more federal government chatbots being released in 2017 and 2018.
 
-{% include image.html img="/raw/lunch-team.png" alt="Chatbot concept with instant messenger displayed on smart phone" width="200" %}
+{% include image.html img="https://www.example.org/img/raw/lunch-team.png" alt="Chatbot concept with instant messenger displayed on smart phone" width="200" %}
 
 So, how do agencies prepare their government datasets for chatbots? The key is to think conversationally. How will users ask about the data and what should the responses be? Follow the steps below to map how your agency’s datasets will be transformed into a conversation.
 


### PR DESCRIPTION
This PR adds an `image.html` component for simple legacy archive images important from the Wordpress site. This component allows for external linking if necessary, and provides a flexible path into the `/assets` directory.